### PR TITLE
Arrays::getLength: include 'from' in exception message

### DIFF
--- a/core/src/main/java/org/bouncycastle/util/Arrays.java
+++ b/core/src/main/java/org/bouncycastle/util/Arrays.java
@@ -895,8 +895,8 @@ public final class Arrays
         int newLength = to - from;
         if (newLength < 0)
         {
-            StringBuffer sb = new StringBuffer(from);
-            sb.append(" > ").append(to);
+            StringBuffer sb = new StringBuffer();
+            sb.append(from).append(" > ").append(to);
             throw new IllegalArgumentException(sb.toString());
         }
         return newLength;

--- a/core/src/main/java/org/bouncycastle/util/Arrays.java
+++ b/core/src/main/java/org/bouncycastle/util/Arrays.java
@@ -821,6 +821,11 @@ public final class Arrays
     public static byte[] copyOfRange(byte[] data, int from, int to)
     {
         int newLength = getLength(from, to);
+        if(newLength < 0) {
+            StringBuffer sb = new StringBuffer();
+            sb.append(from).append(" > ").append(to);
+            throw new IllegalArgumentException(sb.toString());
+        }
 
         byte[] tmp = new byte[newLength];
 


### PR DESCRIPTION
Explicitly pass 'from' as String to the constructor of ByteBuffer
to avoid interpreting it as initial buffer capacity.