### PR TITLE
Add Ed25519 OIDs and signature algorithm mappings

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/edcurves/EdwardsCurvesObjectIdentifiers.java
+++ b/core/src/main/java/org/bouncycastle/asn1/edcurves/EdwardsCurvesObjectIdentifiers.java
@@ -1,0 +1,18 @@
+package org.bouncycastle.asn1.edcurves;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+
+/**
+ *
+ * edwards-curves-algs:
+ *     draft-ietf-curdle-pkix 
+ */
+public interface EdwardsCurvesObjectIdentifiers
+{
+    static final ASN1ObjectIdentifier    edwardsCurvesAlgs       = new ASN1ObjectIdentifier("1.3.101");
+
+    static final ASN1ObjectIdentifier    id_X25519               = edwardsCurvesAlgs.branch("110");
+    static final ASN1ObjectIdentifier    id_X448                 = edwardsCurvesAlgs.branch("111");
+    static final ASN1ObjectIdentifier    id_Ed25519              = edwardsCurvesAlgs.branch("112");
+    static final ASN1ObjectIdentifier    id_Ed448                = edwardsCurvesAlgs.branch("113");
+}

--- a/pkix/src/main/java/org/bouncycastle/operator/DefaultSignatureAlgorithmIdentifierFinder.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/DefaultSignatureAlgorithmIdentifierFinder.java
@@ -12,6 +12,7 @@ import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.bsi.BSIObjectIdentifiers;
 import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers;
 import org.bouncycastle.asn1.eac.EACObjectIdentifiers;
+import org.bouncycastle.asn1.edcurves.EdwardsCurvesObjectIdentifiers;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
@@ -92,6 +93,7 @@ public class DefaultSignatureAlgorithmIdentifierFinder
         algorithms.put("SHA256WITHCVC-ECDSA", EACObjectIdentifiers.id_TA_ECDSA_SHA_256);
         algorithms.put("SHA384WITHCVC-ECDSA", EACObjectIdentifiers.id_TA_ECDSA_SHA_384);
         algorithms.put("SHA512WITHCVC-ECDSA", EACObjectIdentifiers.id_TA_ECDSA_SHA_512);
+        algorithms.put("SHA512WITHED25519", EdwardsCurvesObjectIdentifiers.id_Ed25519);
         //
         // According to RFC 3279, the ASN.1 encoding SHALL (id-dsa-with-sha1) or MUST (ecdsa-with-SHA*) omit the parameters field.
         // The parameters field SHALL be NULL for RSA based signature algorithms.
@@ -106,6 +108,7 @@ public class DefaultSignatureAlgorithmIdentifierFinder
         noParams.add(NISTObjectIdentifiers.dsa_with_sha256);
         noParams.add(NISTObjectIdentifiers.dsa_with_sha384);
         noParams.add(NISTObjectIdentifiers.dsa_with_sha512);
+        noParams.add(EdwardsCurvesObjectIdentifiers.id_Ed25519);
 
         //
         // RFC 4491

--- a/pkix/src/main/java/org/bouncycastle/operator/jcajce/OperatorHelper.java
+++ b/pkix/src/main/java/org/bouncycastle/operator/jcajce/OperatorHelper.java
@@ -27,6 +27,7 @@ import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.bsi.BSIObjectIdentifiers;
 import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers;
 import org.bouncycastle.asn1.eac.EACObjectIdentifiers;
+import org.bouncycastle.asn1.edcurves.EdwardsCurvesObjectIdentifiers;
 import org.bouncycastle.asn1.kisa.KISAObjectIdentifiers;
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.ntt.NTTObjectIdentifiers;
@@ -88,6 +89,7 @@ class OperatorHelper
         oids.put(OIWObjectIdentifiers.dsaWithSHA1, "SHA1WITHDSA");
         oids.put(NISTObjectIdentifiers.dsa_with_sha224, "SHA224WITHDSA");
         oids.put(NISTObjectIdentifiers.dsa_with_sha256, "SHA256WITHDSA");
+        oids.put(EdwardsCurvesObjectIdentifiers.id_Ed25519, "SHA512WITHED25519");
 
         oids.put(OIWObjectIdentifiers.idSHA1, "SHA-1");
         oids.put(NISTObjectIdentifiers.id_sha224, "SHA-224");


### PR DESCRIPTION
This allows easier use of JcaContentSignerBuilder to build X509 certificates like so:

```
JcaX509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(issuer, serial, notBefore, notAfter, subject, publicKey);
ContentSigner contentSigner = new JcaContentSignerBuilder("SHA512withEd25519").setProvider(BC).build(privateKey);
X509Certificate cert = new JcaX509CertificateConverter().setProvider(BC).getCertificate(certBuilder.build(contentSigner));
```

OIDs from [https://tools.ietf.org/html/draft-ietf-curdle-pkix-07](https://tools.ietf.org/html/draft-ietf-curdle-pkix-07)